### PR TITLE
Configure crate-type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,8 @@ name = "{{project-name}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 wasm-bindgen = "0.2"


### PR DESCRIPTION
Otherwise wasm-pack will complain instead of generating a package. Since the template is called `wasm-pack-template` I figured it should work with wasm-pack ootb :wink: