### PR TITLE
Use the new feature flag for procedural macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro, wasm_import_module, wasm_custom_section)]
+#![feature(use_extern_macros, wasm_import_module, wasm_custom_section)]
 
 extern crate wasm_bindgen;
 


### PR DESCRIPTION
The old `proc_macro` flag no longer works with the latest nightly builds, it's called `use_extern_macros` now.