### PR TITLE
fix(licenses): template author name in MIT license

### DIFF
--- a/LICENSE_MIT
+++ b/LICENSE_MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Ashley Williams
+Copyright (c) 2018 {{authors}}
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
Hey there, just saw that the MIT license wasn't using {{ authors }} and here is a PR does!