### PR TITLE
Remove unnecessary #[macro_use]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(use_extern_macros)]
 
-#[macro_use]
 extern crate cfg_if;
 extern crate wasm_bindgen;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,5 @@
+use cfg_if::cfg_if;
+
 cfg_if! {
     // When the `console_error_panic_hook` feature is enabled, we can call the
     // `set_panic_hook` function to get better error messages if we ever panic.


### PR DESCRIPTION
If we are enabling the `use_extern_macros` feature, we don't need to use the old `#[macro_use]` syntax.