### PR TITLE
Remove unnecessary use_extern_macros feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(use_extern_macros)]
-
 extern crate cfg_if;
 extern crate wasm_bindgen;
 


### PR DESCRIPTION
As @fitzgen pointed out in #17, nightly no longer requires the `use_extern_macros` feature :tada: