### PR TITLE
remove meta tag from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<meta charset="utf-8"/>
-
 # 🦀🕸️ `wasm-pack-template`
 
 A template for kick starting a Rust and WebAssembly project using


### PR DESCRIPTION
fixes #29 - @fitzgen i think you added this when you wrote the readme. i would guess that you did this because of the emoji? can you clarify why you added this? meta tags in the HTML body are invalid HTML, though it appears that some browsers will add them to the head for you. i think generally we should look for another solution for this (if this is indeed fixing a bug).