### PR TITLE
feat(ci): update cargo gen to 0.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
     before_script:
       - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
       - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "0.2.2" cargo-generate)
+      - cargo generate --version
       - cargo install-update -a
       - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       chrome: stable
     before_script:
       - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "0.2.2" cargo-generate)
       - cargo install-update -a
       - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
       - cargo install-update -a
       - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
     script:
+      - pwd
       - cargo generate --git . --name testing
       # Having a broken Cargo.toml (in that it has curlies in fields) anywhere
       # in any of our parent dirs is problematic.

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
       - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
     script:
       - pwd
+      - git status
       - cargo generate --git . --name testing
       # Having a broken Cargo.toml (in that it has curlies in fields) anywhere
       # in any of our parent dirs is problematic.


### PR DESCRIPTION
cargo generate 0.2.1 introduce a bug that broke the relative paths undoc'd feature that this repo was leveraging. 0.2.2 fixes that bug and makes relative paths an official feature. this PR should force travis to update cargo-gen to 0.2.2 and should fix the ci breakage we've seen since 0.2.1.