### PR TITLE
Use the 2018 edition in the template

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "{{project-name}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,12 @@
-extern crate cfg_if;
-extern crate wasm_bindgen;
-
 mod utils;
 
 use cfg_if::cfg_if;
 use wasm_bindgen::prelude::*;
 
-cfg_if! {
+cfg_if::cfg_if! {
     // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
     // allocator.
     if #[cfg(feature = "wee_alloc")] {
-        extern crate wee_alloc;
         #[global_allocator]
         static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,8 +8,7 @@ cfg_if! {
     // For more details see
     // https://github.com/rustwasm/console_error_panic_hook#readme
     if #[cfg(feature = "console_error_panic_hook")] {
-        extern crate console_error_panic_hook;
-        pub use self::console_error_panic_hook::set_once as set_panic_hook;
+        pub use console_error_panic_hook::set_once as set_panic_hook;
     } else {
         #[inline]
         pub fn set_panic_hook() {}


### PR DESCRIPTION
Helps remove a number of pesky `extern crate`