### PR TITLE
Remove the cfg-if dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-cfg-if = "0.1.2"
 wasm-bindgen = "0.2"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,12 @@
 mod utils;
 
-use cfg_if::cfg_if;
 use wasm_bindgen::prelude::*;
 
-cfg_if::cfg_if! {
-    // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-    // allocator.
-    if #[cfg(feature = "wee_alloc")] {
-        #[global_allocator]
-        static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-    }
-}
+// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
+// allocator.
+#[cfg(feature = "wee_alloc")]
+#[global_allocator]
+static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 #[wasm_bindgen]
 extern {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,16 +1,10 @@
-use cfg_if::cfg_if;
-
-cfg_if! {
+pub fn set_panic_hook() {
     // When the `console_error_panic_hook` feature is enabled, we can call the
     // `set_panic_hook` function at least once during initialization, and then
     // we will get better error messages if our code ever panics.
     //
     // For more details see
     // https://github.com/rustwasm/console_error_panic_hook#readme
-    if #[cfg(feature = "console_error_panic_hook")] {
-        pub use console_error_panic_hook::set_once as set_panic_hook;
-    } else {
-        #[inline]
-        pub fn set_panic_hook() {}
-    }
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
 }


### PR DESCRIPTION
In the 2018 edition turns out we only need to cfg one statement at a
time, so need to pull in a whole macro from a crate to do it!