### PR TITLE
Set date in license using template

### DIFF
--- a/LICENSE_MIT
+++ b/LICENSE_MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2018 {{authors}}
+Copyright (c) {{ "now" | date: "%Y" }} {{authors}}
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
The date in the MIT license is hard-coded to `2018`. With a Liquid template, it can be set to the current year automatically in new projects.