### PR TITLE
Remove Cargo.lock from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /target
 **/*.rs.bk
-Cargo.lock
 bin/
 pkg/
 wasm-pack.log


### PR DESCRIPTION
Hey there,

usually, commiting the Cargo.lock file ensures that builds are reproducible in the future, even when transitive dependencies change.

If there has been an argument against commiting it, please let me know.