### PR TITLE
Version of wasm-bindgen-test should be at least 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ console_error_panic_hook = { version = "0.1.1", optional = true }
 wee_alloc = { version = "0.4.2", optional = true }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.2"
+wasm-bindgen-test = "0.3"
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.


### PR DESCRIPTION
When generating a project from this template no tests were found:

```
Finished test [unoptimized + debuginfo] target(s) in 0.02s
     Running target/wasm32-unknown-unknown/debug/deps/blah-7db56ece65bf5366.wasm
no tests to run!
     Running target/wasm32-unknown-unknown/debug/deps/web-25878581c076d778.wasm
no tests to run!
```
I found out it was because the version of `wasm-bindgen-test` needs to be `0.3` and not `0.2`.

Running on Rust version 1.43.1