### PR TITLE
Fix wasm-opt 'Exported global cannot be mutable'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ wee_alloc = { version = "0.4.5", optional = true }
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
 
+# Workaround for https://github.com/rustwasm/wasm-pack/issues/886
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O", "--enable-mutable-globals"]
+
 [profile.release]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"


### PR DESCRIPTION
`wasm-pack build` currently fails on this step of the tutorial: https://rustwasm.github.io/docs/book/game-of-life/implementing.html
This is due to incompatible change in wasm-bindgen 0.2.66. Issue is described here: https://github.com/rustwasm/wasm-pack/issues/886
rustwasm / book issue: https://github.com/rustwasm/book/issues/237