### PR TITLE
Force wasm-bindgen to use 0.2.65

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-wasm-bindgen = "0.2.63"
+wasm-bindgen = "=0.2.65"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires


### PR DESCRIPTION
I was going through the (Rust and wasm tutorial)[https://rustwasm.github.io/docs/book/introduction.html] and ran into some issues with wasm-bindgen 0.2.66.
Other people are also experiencing (issues here)[https://github.com/rustwasm/wasm-pack/issues/886#issuecomment-665953933]

This change pins wasm-bindgen version to 0.2.65 in accordance to the solution above.