### PR TITLE
Specify `wasm32-unknown-unknown` target inside `.cargo/config`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"


### PR DESCRIPTION
The target setting in the cargo config can provide IDEs with an understanding of which target-specific code insight to show in the project. Both IntelliJ Rust and rust-analyzer respect this setting.

In IntelliJ Rust, the `wasm-pack-template` is one of the options to create a new project, and the inclusion of such a config setting seems to be convenient.

Related to https://github.com/intellij-rust/intellij-rust/issues/7262